### PR TITLE
feat: Display episode duration on weekly pages

### DIFF
--- a/src/pages/weekly/index.astro
+++ b/src/pages/weekly/index.astro
@@ -32,6 +32,11 @@ const sortedEpisodes = episodes.sort((a, b) => b.data.id - a.data.id);
 				font-size: 1.5rem;
 				margin-bottom: 0.5rem;
 			}
+			.episode-duration {
+				font-size: 0.9rem;
+				color: #555;
+				margin-bottom: 0.5rem;
+			}
 			.episode-description {
 				margin-bottom: 0.5rem;
 				line-height: 1.6;
@@ -59,6 +64,7 @@ const sortedEpisodes = episodes.sort((a, b) => b.data.id - a.data.id);
 								Episode #{episode.data.id}: {episode.data.title}
 							</a>
 						</h2>
+						{episode.data.duration && <p class="episode-duration">Duration: {episode.data.duration}</p>}
 					<div class="episode-tags">
 						{episode.data.tags.split(',').map((tag) => (
 							<span class="tag">#{tag}</span>


### PR DESCRIPTION
This commit introduces the display of episode duration on the weekly episode list page.

- Modified `src/pages/weekly/index.astro` to include the `duration` field from the episode data.
- Added basic styling for the duration display to ensure consistency with the existing layout.
- Verified that the duration also continues to be correctly displayed on the individual episode detail page.