### PR TITLE
Improve SEO: article OG tags, sitemap metadata, unified RSS feed

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,60 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+```bash
+npm run dev       # start dev server at http://localhost:4321
+npm run build     # build static site to dist/
+npm run preview   # preview the built dist/
+```
+
+No test suite. Verify changes with `npm run build` and manual review in the dev server.
+
+## Stack
+
+- **Astro 5** (static output, MDX, sitemap, RSS integrations)
+- **Tailwind CSS 4** via `@tailwindcss/vite` plugin — no config file, imported directly in `src/styles/global.css`
+- **CodeMirror 6** — replaces native `<pre>` blocks on page load with read-only syntax-highlighted editors
+- **TypeScript** (tsconfig at root, strict: false)
+
+## Architecture
+
+### Content Collections
+
+Defined in `src/content.config.ts`. Three collections:
+
+| Collection | Source directory | Key fields |
+|---|---|---|
+| `blog` | `src/content/blog/` | `title`, `description`, `pubDate`, `updatedDate?`, `heroImage?` |
+| `notes` | `src/content/notes/` | same as blog + `tags?` (comma-separated string) |
+| `episodes` | `src/content/episodes/` | `id` (number), `title`, `description`, `published`, `audioLink`, `publishDate`, `duration`, `tags` (comma-separated) |
+
+Notes are organized into subfolders (e.g. `src/content/notes/data-structure/`). The notes index page groups them by folder name (title-cased), with `misc` as the fallback for root-level files.
+
+### Pages and Routing
+
+- `src/pages/index.astro` — home
+- `src/pages/blog/[...slug].astro` — blog post (uses `BlogPost.astro` layout)
+- `src/pages/notes/[...slug].astro` — note detail (uses `BlogPost.astro` layout)
+- `src/pages/notes/tag/[tag].astro` — notes filtered by tag
+- `src/pages/weekly/index.astro` — episode list (first page, 10 per page)
+- `src/pages/weekly/page/[page].astro` — paginated episodes
+- `src/pages/weekly/[id].astro` — single episode (keyed by `id` number, not slug)
+
+### Shared Layout
+
+`BlogPost.astro` is the single layout used by both blog posts and notes. It injects CodeMirror via `<script>import "../scripts/codemirror-loader.js"</script>` in its `<body>` tail. The loader (`src/scripts/codemirror-loader.js`) runs at page load, finds all `<pre>` elements, and replaces them with read-only CodeMirror editors with VSCode light/dark themes.
+
+### Theming
+
+All colors use CSS custom properties defined in `src/styles/global.css`. Light mode is default; dark mode is toggled by setting `data-theme="dark"` on `<html>`. The `Header.astro` component manages the toggle with localStorage persistence. The CSS variables (`--navy`, `--light-navy`, `--slate`, `--green`, etc.) are used throughout both component inline styles and Tailwind arbitrary values like `text-[var(--green)]`.
+
+### Global Constants
+
+`src/consts.ts` exports `SITE_TITLE` and `SITE_DESCRIPTION` used across pages for `<BaseHead>` titles.
+
+## Deployment
+
+Static output goes to `dist/`. Deployed to GitHub Pages at `madhusudhansubedi.com.np` (see `CNAME`). The `astro.config.mjs` sets `site: 'https://madhusudhansubedi.com.np'` which affects sitemap and canonical URLs.

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -8,6 +8,9 @@ interface Props {
 	title: string;
 	description: string;
 	image?: string;
+	type?: "website" | "article";
+	pubDate?: Date;
+	updatedDate?: Date;
 }
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site);
@@ -15,8 +18,13 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 const {
 	title,
 	description,
-	image = "/images/blogs/database-normalization.png",
+	image = "/images/madhusudhansubedi.JPG",
+	type = "website",
+	pubDate,
+	updatedDate,
 } = Astro.props;
+
+const ogImage = new URL(image, Astro.site);
 ---
 
 <!-- Theme Initialization Script -->
@@ -32,22 +40,6 @@ const {
 <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
 <meta name="generator" content={Astro.generator} />
 
-<!-- Font preloads -->
-<link
-	rel="preload"
-	href="/fonts/atkinson-regular.woff"
-	as="font"
-	type="font/woff"
-	crossorigin
-/>
-<link
-	rel="preload"
-	href="/fonts/atkinson-bold.woff"
-	as="font"
-	type="font/woff"
-	crossorigin
-/>
-
 <!-- Canonical URL -->
 <link rel="canonical" href={canonicalURL} />
 
@@ -55,6 +47,8 @@ const {
 <title>{title}</title>
 <meta name="title" content={title} />
 <meta name="description" content={description} />
+<meta name="author" content="Madhu Sudhan Subedi" />
+<meta name="robots" content="index, follow" />
 <link
 	rel="alternate"
 	type="application/rss+xml"
@@ -64,19 +58,25 @@ const {
 <link rel="manifest" href="/manifest.json" />
 <meta name="theme-color" content="#000000" />
 
-<!-- Open Graph / Facebook -->
-<meta property="og:type" content="website" />
+<!-- Open Graph -->
+<meta property="og:type" content={type} />
 <meta property="og:url" content={Astro.url} />
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description} />
-<meta property="og:image" content={new URL(image, Astro.url)} />
+<meta property="og:image" content={ogImage} />
+<meta property="og:image:alt" content={title} />
 <meta property="og:site_name" content={SITE_TITLE} />
+<meta property="og:locale" content="en_US" />
+{type === "article" && pubDate && <meta property="article:published_time" content={pubDate.toISOString()} />}
+{type === "article" && updatedDate && <meta property="article:modified_time" content={updatedDate.toISOString()} />}
+{type === "article" && <meta property="article:author" content="Madhu Sudhan Subedi" />}
 
 <!-- Twitter -->
 <meta property="twitter:card" content="summary_large_image" />
 <meta property="twitter:url" content={Astro.url} />
 <meta property="twitter:title" content={title} />
 <meta property="twitter:description" content={description} />
-<meta property="twitter:image" content={new URL(image, Astro.url)} />
+<meta property="twitter:image" content={ogImage} />
+<meta property="twitter:image:alt" content={title} />
 <meta name="twitter:site" content="@xmadhusudhan" />
 <meta name="twitter:creator" content="@xmadhusudhan" />

--- a/src/layouts/BlogPost.astro
+++ b/src/layouts/BlogPost.astro
@@ -22,7 +22,7 @@ const tagList: string[] =
 
 <html lang="en">
 	<head>
-		<BaseHead title={title} description={description} image={heroImage ? `/${heroImage}` : undefined} />
+		<BaseHead title={title} description={description} image={heroImage ? `/${heroImage}` : undefined} type="article" pubDate={pubDate} updatedDate={updatedDate} />
 	</head>
 
 	<body class="bg-[var(--navy)] text-[var(--slate)] font-sans antialiased">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -17,12 +17,10 @@ import {
 <html lang="en">
 	<head>
 		<BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
-		<meta name="robots" content="index, follow" />
 		<meta
 			name="keywords"
-			content="software engineer, Japan, Nepal, Astro, React, Node.js, web development"
+			content="software engineer, Japan, Nepal, Astro, React, Node.js, web development, Laravel, PHP, backend"
 		/>
-		<link rel="canonical" href="https://madhusudhansubedi.com.np" />
 	</head>
 	<body
 		class="bg-[var(--navy)] text-[var(--slate)] font-sans antialiased selection:bg-[var(--green)] selection:text-[var(--navy)]"

--- a/src/pages/rss.xml.js
+++ b/src/pages/rss.xml.js
@@ -3,14 +3,43 @@ import { getCollection } from 'astro:content';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 
 export async function GET(context) {
-	const posts = await getCollection('blog');
+	const [posts, notes, episodes] = await Promise.all([
+		getCollection('blog'),
+		getCollection('notes'),
+		getCollection('episodes'),
+	]);
+
+	const blogItems = posts.map((post) => ({
+		title: post.data.title,
+		description: post.data.description,
+		pubDate: post.data.pubDate,
+		link: `/blog/${post.id}/`,
+	}));
+
+	const noteItems = notes.map((note) => ({
+		title: note.data.title,
+		description: note.data.description,
+		pubDate: note.data.pubDate,
+		link: `/notes/${note.id}/`,
+	}));
+
+	const episodeItems = episodes
+		.filter((e) => e.data.published)
+		.map((e) => ({
+			title: `Episode #${e.data.id}: ${e.data.title}`,
+			description: e.data.description,
+			pubDate: new Date(e.data.publishDate),
+			link: `/weekly/${e.data.id}/`,
+		}));
+
+	const allItems = [...blogItems, ...noteItems, ...episodeItems].sort(
+		(a, b) => b.pubDate.valueOf() - a.pubDate.valueOf()
+	);
+
 	return rss({
 		title: SITE_TITLE,
 		description: SITE_DESCRIPTION,
 		site: context.site,
-		items: posts.map((post) => ({
-			...post.data,
-			link: `/blog/${post.id}/`,
-		})),
+		items: allItems,
 	});
 }

--- a/src/pages/sitemap.xml.js
+++ b/src/pages/sitemap.xml.js
@@ -6,23 +6,47 @@ export async function GET() {
   const blog = await getCollection('blog')
   const episodes = await getCollection('episodes')
 
-  const staticPaths = [
-    '/',
-    '/blog/',
-    '/notes/',
-    '/weekly/',
+  const now = new Date().toISOString().split('T')[0]
+
+  const staticPages = [
+    { path: '/', priority: '1.0', changefreq: 'weekly' },
+    { path: '/blog/', priority: '0.8', changefreq: 'weekly' },
+    { path: '/notes/', priority: '0.8', changefreq: 'weekly' },
+    { path: '/weekly/', priority: '0.8', changefreq: 'weekly' },
   ]
 
-  const urls = [
-    ...staticPaths.map((p) => `${base}${p}`),
-    ...notes.map((n) => `${base}/notes/${n.id}/`),
-    ...blog.map((b) => `${base}/blog/${b.id}/`),
-    ...episodes.map((e) => `${base}/weekly/${e.data.id}/`)
+  const allTags = Array.from(
+    new Set(
+      notes
+        .map((n) => n.data.tags)
+        .filter((t) => typeof t === 'string' && t.length > 0)
+    )
+  )
+
+  const entries = [
+    ...staticPages.map(({ path, priority, changefreq }) =>
+      `<url><loc>${base}${path}</loc><lastmod>${now}</lastmod><changefreq>${changefreq}</changefreq><priority>${priority}</priority></url>`
+    ),
+    ...blog.map((b) => {
+      const lastmod = (b.data.updatedDate ?? b.data.pubDate).toISOString().split('T')[0]
+      return `<url><loc>${base}/blog/${b.id}/</loc><lastmod>${lastmod}</lastmod><changefreq>monthly</changefreq><priority>0.7</priority></url>`
+    }),
+    ...notes.map((n) => {
+      const lastmod = (n.data.updatedDate ?? n.data.pubDate).toISOString().split('T')[0]
+      return `<url><loc>${base}/notes/${n.id}/</loc><lastmod>${lastmod}</lastmod><changefreq>monthly</changefreq><priority>0.6</priority></url>`
+    }),
+    ...allTags.map((tag) =>
+      `<url><loc>${base}/notes/tag/${tag}/</loc><lastmod>${now}</lastmod><changefreq>weekly</changefreq><priority>0.5</priority></url>`
+    ),
+    ...episodes.map((e) => {
+      const lastmod = new Date(e.data.publishDate).toISOString().split('T')[0]
+      return `<url><loc>${base}/weekly/${e.data.id}/</loc><lastmod>${lastmod}</lastmod><changefreq>never</changefreq><priority>0.6</priority></url>`
+    }),
   ]
 
   const xml = `<?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
-${urls.map((u) => `<url><loc>${u}</loc></url>`).join('\n')}
+${entries.join('\n')}
 </urlset>`
 
   return new Response(xml, {

--- a/src/pages/weekly/[id].astro
+++ b/src/pages/weekly/[id].astro
@@ -37,12 +37,12 @@ const audioLink = `https://weekly.madhusudhansubedi.com.np/embed/${episode.data.
 					'description': episode.data.description,
 					'datePublished': new Date(episode.data.publishDate).toISOString(),
 					'duration': episode.data.duration || undefined,
-					'url': `/weekly/${episode.data.id}`,
+					'url': `https://madhusudhansubedi.com.np/weekly/${episode.data.id}`,
 					'embedUrl': audioLink,
 					'partOfSeries': {
 						'@type': 'PodcastSeries',
 						'name': 'Madhu Sudhan Subedi Tech Weekly',
-						'url': '/weekly'
+						'url': 'https://madhusudhansubedi.com.np/weekly'
 					}
 				})}
 			</script>


### PR DESCRIPTION
- BaseHead: add type/pubDate/updatedDate props; set og:type per page; add article:published_time, article:modified_time, article:author for articles; add og:image:alt, twitter:image:alt, og:locale, meta author/robots on all pages; remove unused Atkinson font preloads; fix default OG image
- BlogPost: pass type="article" and dates to BaseHead
- index.astro: remove duplicate hardcoded canonical; move robots/keywords inline
- weekly/[id].astro: use absolute URLs in PodcastEpisode JSON-LD
- sitemap.xml: add lastmod, changefreq, priority per URL type; include tag pages
- rss.xml: expand feed to include notes and published episodes, sorted by date
- Add CLAUDE.md with project architecture and command reference