### PR TITLE
Remove Work in Progress label from homepage audio streaming project

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -461,10 +461,7 @@ import {
 										An audio streaming platform for my Tech
 										Weekly podcast episodes, featuring a
 										custom player, episode management, and
-										content delivery. <span
-											class="inline-block bg-[var(--green)] text-[var(--navy)] text-xs font-bold px-2 py-1 rounded ml-2 uppercase tracking-wide"
-											>Work in Progress</span
-										>
+										content delivery.
 									</p>
 								</div>
 								<ul


### PR DESCRIPTION
## Summary
- Removes the "Work in Progress" badge from the Tech Weekly Audio Streaming project card on the homepage

## Test plan
- [x] `npm run build` completes successfully


---
_Generated by [Claude Code](https://claude.ai/code/session_01V5oHQuiMTDXhYmwENvNVMJ)_